### PR TITLE
campusdomar/PuMuKIT2#90 Fixed 'next' button

### DIFF
--- a/Resources/public/templates/stats_objects_general.html
+++ b/Resources/public/templates/stats_objects_general.html
@@ -58,7 +58,7 @@
               <a href="#" ng-click="pmkCtrl.go_to_page(page)"> {{page}}</a>
               </li>
               <li ng-class="{'disabled': pmkCtrl.page.mv == pmkCtrl.total_pages.mv}">
-              <a href="#" ng-click="pmkCtrl.go_to_page(pmkCtrl.page.mv +1)" > Next </a>
+              <a href="#" ng-click="pmkCtrl.go_to_page(pmkCtrl.page.mv * 1 + 1);" > Next </a>
               </li>
             </ul>
           </div>

--- a/Resources/public/templates/stats_objects_particular.html
+++ b/Resources/public/templates/stats_objects_particular.html
@@ -35,7 +35,7 @@
             <div class="pumukit_mmobj">
               <div class="thumbnail">
                 <span class="play_icon" alt=""></span>
-                <span class="video-duration">{{(pmkCtrl.scope.duration * 1000) | asDuration}}</span>
+                <span class="video-duration">{{(pmkCtrl.current.duration * 1000) | asDuration}}</span>
                 <img alt="serial_pic" class="serial thumbnailimg" ng-src="{{pmkCtrl.current.img}}">
                 <div class="thumbnailholder"></div>
               </div>

--- a/Resources/public/templates/stats_series_general.html
+++ b/Resources/public/templates/stats_series_general.html
@@ -55,7 +55,7 @@
               <a href="#" ng-click="pmkCtrl.go_to_page(page)"> {{page}}</a>
               </li>
               <li ng-class="{'disabled':pmkCtrl.page.mv == pmkCtrl.total_pages.mv}">
-              <a href="#" ng-click="pmkCtrl.go_to_page(pmkCtrl.page.mv + 1)" > Next </a>
+              <a href="#" ng-click="pmkCtrl.go_to_page(pmkCtrl.page.mv * 1 + 1)" > Next </a>
               </li>
             </ul>
           </div>

--- a/Resources/public/templates/stats_series_particular.html
+++ b/Resources/public/templates/stats_series_particular.html
@@ -57,7 +57,7 @@
               <a href="#" ng-click="pmkCtrl.go_to_page(page)"> {{page}}</a>
               </li>
               <li ng-class="{'disabled':pmkCtrl.page.mv == pmkCtrl.total_pages.mv}">
-              <a href="#" ng-click="pmkCtrl.go_to_page(pmkCtrl.page.mv + 1)" > Next </a>
+              <a href="#" ng-click="pmkCtrl.go_to_page(pmkCtrl.page.mv * 1 + 1)" > Next </a>
               </li>
             </ul>
           </div>


### PR DESCRIPTION
The 'pmkCtrl.page.mv' variable is a string!
Multiplying by 1 makes it turn into an integer.

Other options are implementing a filter that uses 'parseInt' or making sure that pmkCtrl.page.mv is an INT as it should.
