### PR TITLE
Fix PuMuKIT2 require version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "pumukit/pumukit2": ">=2.2.x"
+        "pumukit/pumukit2": ">=2.2.*"
     },
     "homepage": "https://github.com/teltek/PuMuKIT2-stats-ui-bundle",
     "license": "Copyright",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "pumukit/pumukit2": ">=2.2"
+        "pumukit/pumukit2": ">=2.2.x"
     },
     "homepage": "https://github.com/teltek/PuMuKIT2-stats-ui-bundle",
     "license": "Copyright",


### PR DESCRIPTION
This bundle is not being installed in branch `2.2.x` of PuMuKIT2.
The require version in composer.json needs to be changed from `2.2` to `2.2.*` to allow to be used in `2.2.x` or `2.2.*` tags of PuMuKIT2.
**NOTE:** PuMuKIT2 requires the installation of this bundle in version `1.0.*`, so it won't use the branch `1.0.x`, the tag `1.0.1` needs to be created.
